### PR TITLE
fix: `ingress-controller.yaml` 

### DIFF
--- a/doc/deploy/deploy.md
+++ b/doc/deploy/deploy.md
@@ -57,7 +57,7 @@ spec:
     shortNames:
     - ar
 
----------------------
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -76,8 +76,7 @@ spec:
     shortNames:
     - as
 
------------------------
-
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/doc/dev/develop.md
+++ b/doc/dev/develop.md
@@ -53,7 +53,7 @@ spec:
     shortNames:
     - ar
 
----------------------
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -72,8 +72,7 @@ spec:
     shortNames:
     - as
 
------------------------
-
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/samples/deploy/deployment/ingress-controller.yaml
+++ b/samples/deploy/deployment/ingress-controller.yaml
@@ -8,7 +8,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: apisix
+      app: apisix-ingress-controller
       tier: backend
   strategy:
     rollingUpdate:
@@ -19,7 +19,7 @@ spec:
     metadata:
       annotations: {}
       labels:
-        app: apisix
+        app: apisix-ingress-controller
         tier: backend
     spec:
       hostNetwork: true

--- a/samples/deploy/deployment/ingress-controller.yaml
+++ b/samples/deploy/deployment/ingress-controller.yaml
@@ -8,7 +8,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: ingress-controller
+      app: apisix
       tier: backend
   strategy:
     rollingUpdate:


### PR DESCRIPTION
When i use `kubectl apply -f ingress-controller.yaml`, i get following error:
```shell
[root@k8s-master eplat-yamls]# kubectl apply -f ingress-controller.yaml 
The Deployment "ingress-controller" is invalid: spec.template.metadata.labels: Invalid value: map[string]string{"app":"apisix", "tier":"backend"}: `selector` does not match template `labels`
```

Must modify the `ingress-controller.yaml`:
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: ingress-controller
  namespace: cloud
spec:
  minReadySeconds: 5
  replicas: 1
  selector:
    matchLabels:
      app: apisix # Change 'ingress-controller' to 'apisix'
      tier: backend
  strategy:
    rollingUpdate:
      maxSurge: 50%
      maxUnavailable: 1
    type: RollingUpdate
  template:
    metadata:
      annotations: {}
      labels:
        app: apisix
        tier: backend
    spec:
      hostNetwork: true
      containers:
      - envFrom:
        - configMapRef:
            name: cloud-config
        image: api7/ingress-controller:v3
        imagePullPolicy: IfNotPresent
        name: ingress-controller
        ports:
        - containerPort: 8080
          hostPort: 8080
      terminationGracePeriodSeconds: 60
```